### PR TITLE
Add support for listing buckets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /lib/
 /node_modules/
+/log/

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "bin"
   ],
   "dependencies": {
+    "aws-sdk": "^2.1.12",
     "underscore": "^1.6.0",
     "blessed": "0.0.37",
-    "knox": "^0.9.0",
     "moment": "^2.7.0",
     "underscore.string": "^2.3.3",
     "docopt": "^0.4.0",

--- a/spec/tetra/client_spec.coffee
+++ b/spec/tetra/client_spec.coffee
@@ -15,7 +15,7 @@ describe 'Client', ->
   describe '#list', ->
     it 'passes the path to the underlying client', (done) ->
       @s3Client.listObjects = (options) ->
-        options.Marker.should.equal('foo/')
+        options.Prefix.should.equal('foo/')
         options.Delimiter.should.equal('/')
         options.Bucket.should.equal('bar')
         done()

--- a/spec/tetra/client_spec.coffee
+++ b/spec/tetra/client_spec.coffee
@@ -8,47 +8,49 @@ describe 'Client', ->
     info: ->
     warn: ->
   def 's3Client', ->
-    list: ->
+    listObjects: ->
+    listBuckets: ->
   subject -> new Client(@logger, @s3Client)
 
   describe '#list', ->
     it 'passes the path to the underlying client', (done) ->
-      @s3Client.list = (options) ->
-        options.prefix.should.equal('foo/')
-        options.delimiter.should.equal('/')
+      @s3Client.listObjects = (options) ->
+        options.Marker.should.equal('foo/')
+        options.Delimiter.should.equal('/')
+        options.Bucket.should.equal('bar')
         done()
-      @subject.list('foo/')
+      @subject.list('foo/','bar')
 
     it 'does not include root prefix', ->
-      @s3Client.list = (options, callback) ->
+      @s3Client.listObjects = (options, callback) ->
         callback null,
           CommonPrefixes: [
             Prefix: '/'
           ]
           Contents: []
-      @subject.list('').should.eventually.be.empty
+      @subject.list('','foo').should.eventually.be.empty
 
     it 'transforms prefixes into directory structure', ->
-      @s3Client.list = (options, callback) ->
+      @s3Client.listObjects = (options, callback) ->
         callback null,
           CommonPrefixes: [
             Prefix: 'foo/'
           ]
           Contents: []
-      @subject.list('').should.eventually.eql [
+      @subject.list('','bar').should.eventually.eql [
         type: 'directory'
         path: 'foo/'
       ]
 
     it 'transforms prefixes into file structure', ->
-      @s3Client.list = (options, callback) ->
+      @s3Client.listObjects = (options, callback) ->
         callback null,
           Contents: [
             Key: 'foo/bar'
             StorageClass: 'STANDARD'
             Size: 123
           ]
-      @subject.list('').should.eventually.eql [
+      @subject.list('','bar').should.eventually.eql [
         type: 'file'
         path: 'foo/bar'
         mode: 'S'
@@ -56,16 +58,16 @@ describe 'Client', ->
       ]
 
     it 'includes parent directory when listing something other than the root', ->
-      @s3Client.list = (options, callback) ->
+      @s3Client.listObjects = (options, callback) ->
         callback null,
           Contents: []
-      @subject.list('bar/').should.eventually.eql [
+      @subject.list('bar/','foo').should.eventually.eql [
         type: 'directory'
         path: 'bar/../'
       ]
 
     it 'rejects the promise if the client returns an error', ->
       err = new Error('damnit')
-      @s3Client.list = (options, callback) ->
+      @s3Client.listObjects = (options, callback) ->
         callback err, null
-      @subject.list('bar/').should.be.rejectedWith(err)
+      @subject.list('bar/','foo').should.be.rejectedWith(err)

--- a/spec/tetra_spec.coffee
+++ b/spec/tetra_spec.coffee
@@ -5,15 +5,3 @@ path = require('path')
 es = require('event-stream')
 
 describe 'Tetra CLI', ->
-  it 'prints usage information when given no arguments', (done) ->
-    cmd = spawn path.resolve(__dirname, '../bin/tetra')
-    cmd.stdout.pipe es.wait (err, str) ->
-      throw err if err
-      str.should.match(/^Usage/)
-      done()
-
-  it 'returns code 1 when given no arguments', (done) ->
-    cmd = spawn path.resolve(__dirname, '../bin/tetra')
-    cmd.on 'close', (code) ->
-      code.should.equal 1
-      done()

--- a/src/tetra/client.coffee
+++ b/src/tetra/client.coffee
@@ -5,7 +5,12 @@ class Client
   constructor: (@logger, @s3Client) ->
   listObjects: (path, s3Bucket) ->
     deferred = defer()
-    @s3Client.listObjects Marker: path, Delimiter: '/', Bucket: s3Bucket, (err, data) =>
+    @logger.info 'path', path
+    listOptions =
+      Prefix: path
+      Delimiter: '/'
+      Bucket: s3Bucket
+    @s3Client.listObjects listOptions, (err, data) =>
       if err
         @logger.warn "Client error: #{err}"
         return deferred.reject(err)

--- a/src/tetra/controller.coffee
+++ b/src/tetra/controller.coffee
@@ -1,7 +1,7 @@
 {spawn} = require 'child_process'
 
 class Controller
-  constructor: (@logger, @ui, @client) ->
+  constructor: (@logger, @ui, @client, @s3Bucket) ->
   run: ->
     @ui.run()
     @_list('')
@@ -9,6 +9,9 @@ class Controller
         switch item.type
           when 'directory'
             @_list(item.path)
+          when 'bucket'
+            @s3Bucket = item.name
+            @_list('/')
 
   _list: (path) ->
     if path?
@@ -17,7 +20,8 @@ class Controller
       path = @lastPath
     @ui.load('Listing prefix...')
     @ui.render()
-    list = @client.list(path)
+
+    list = @client.list(path, @s3Bucket)
     list.then (items) =>
       @ui.stopLoad()
       @ui.fileList.setItems items

--- a/src/tetra/ui.coffee
+++ b/src/tetra/ui.coffee
@@ -70,6 +70,7 @@ class UI.FileList extends EventEmitter
     # @parent.render()
 
   _renderItem: (item) ->
+    return item.name if item.type == 'bucket'
     return item.message if item.type == 'message'
     @logger.info item
     fileMode = item.mode or item.type[0]


### PR DESCRIPTION
This PR adds the following changes:
- Replaces knox with AWS node sdk
- Support for listing buckets when no argument is given to Tetra.

If an argument is supplied, Tetra will still treat this as a bucket name.
